### PR TITLE
Remove max version constraint on activemodel

### DIFF
--- a/validate_as_email.gemspec
+++ b/validate_as_email.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = ValidateAsEmail::VERSION
   gem.platform      = Gem::Platform::RUBY
 
-  gem.add_dependency 'activemodel', '> 3', '< 5'
+  gem.add_dependency 'activemodel', '> 3'
   gem.add_dependency 'mail', '~> 2.5'
 end


### PR DESCRIPTION
User Service uses this gem, and I want to upgrade it to newer Rails version...